### PR TITLE
Github Action: Build simavr for Linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,11 @@
+name: Build simavr
+on: [push]
+jobs:
+  build-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        run: sudo apt-get install libelf-dev freeglut3-dev gcc-avr avr-libc
+      - name: Build
+        run: make


### PR DESCRIPTION
This adds a Github Action running make on Linux.
Actions are set up to run on every push.

Example of action running on [my fork](https://github.com/hsorbo/simavr/actions/runs/2144781238)